### PR TITLE
Use site baseurl for home navigation links

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,27 +14,27 @@ Welcome to the **Clinical Content Management System (CCMS)** documentation porta
 
 <div class="grid-container">
   <div class="grid-item">
-    <h3><a href="/ccms-wiki/protocols/">📋 Clinical Protocols</a></h3>
+    <h3><a href="{{ site.baseurl }}/protocols/">📋 Clinical Protocols</a></h3>
     <p>Evidence-based clinical protocols for common conditions and treatments</p>
   </div>
   
   <div class="grid-item">
-    <h3><a href="/ccms-wiki/guidelines/">📄 Practice Guidelines</a></h3>
+    <h3><a href="{{ site.baseurl }}/guidelines/">📄 Practice Guidelines</a></h3>
     <p>Standardized practice guidelines and quality improvement standards</p>
   </div>
   
   <div class="grid-item">
-    <h3><a href="/ccms-wiki/procedures/">⚕️ Procedures</a></h3>
+    <h3><a href="{{ site.baseurl }}/procedures/">⚕️ Procedures</a></h3>
     <p>Step-by-step medical procedures and clinical techniques</p>
   </div>
   
   <div class="grid-item">
-    <h3><a href="/ccms-wiki/medications/">💊 Medications</a></h3>
+    <h3><a href="{{ site.baseurl }}/medications/">💊 Medications</a></h3>
     <p>Drug information, dosing guidelines, and prescribing protocols</p>
   </div>
   
   <div class="grid-item">
-    <h3><a href="/ccms-wiki/references/">📚 References</a></h3>
+    <h3><a href="{{ site.baseurl }}/references/">📚 References</a></h3>
     <p>Clinical references, guidelines, and evidence-based resources</p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- replace the home page quick navigation links to use `{{ site.baseurl }}` instead of a hard-coded `/ccms-wiki` prefix

## Testing
- ⚠️ `bundle exec jekyll serve --detach` *(fails before launch because the jekyll executable is missing without the gem dependencies installed)*
- ⚠️ `bundle install` *(fails with Gem::Net::HTTPClientException 403 when fetching gems from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e28198b46c832c921036739203e04c