### PR TITLE
Use relative_url for navigation links

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,12 +13,12 @@
           {% if folderitem.external_url %}
           <li><a title="{{folderitem.title}}" href="{{folderitem.external_url}}" target="_blank" rel="noopener">{{folderitem.title}}</a></li>
           {% elsif page.url == folderitem.url %}
-          <li class="active"><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+          <li class="active"><a title="{{folderitem.title}}" href="{{folderitem.url | relative_url}}">{{folderitem.title}}</a></li>
           {% elsif folderitem.type == "empty" %}
-          <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+          <li><a title="{{folderitem.title}}" href="{{folderitem.url | relative_url}}">{{folderitem.title}}</a></li>
 
           {% else %}
-          <li><a title="{{folderitem.title}}" href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+          <li><a title="{{folderitem.title}}" href="{{folderitem.url | relative_url}}">{{folderitem.title}}</a></li>
           {% endif %}
           {% for subfolders in folderitem.subfolders %}
           {% if subfolders.output contains "web" %}
@@ -30,9 +30,9 @@
                   {% if subfolderitem.external_url %}
                   <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.external_url}}" target="_blank" rel="noopener">{{subfolderitem.title}}</a></li>
                   {% elsif page.url == subfolderitem.url %}
-                  <li class="active"><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                  <li class="active"><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | relative_url}}">{{subfolderitem.title}}</a></li>
                   {% else %}
-                  <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                  <li><a title="{{subfolderitem.title}}" href="{{subfolderitem.url | relative_url}}">{{subfolderitem.title}}</a></li>
                   {% endif %}
                   {% endif %}
                   {% endfor %}

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -24,9 +24,9 @@
                 {% if item.external_url %}
                 <li><a href="{{item.external_url}}" target="_blank" rel="noopener">{{item.title}}</a></li>
                 {% elsif page.url contains item.url %}
-                <li class="active"><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
+                <li class="active"><a href="{{item.url | relative_url}}">{{item.title}}</a></li>
                 {% else %}
-                <li><a href="{{item.url | remove: "/"}}">{{item.title}}</a></li>
+                <li><a href="{{item.url | relative_url}}">{{item.title}}</a></li>
                 {% endif %}
                 {% endfor %}
                 {% endfor %}
@@ -41,9 +41,9 @@
                         {% if folderitem.external_url %}
                         <li><a href="{{folderitem.external_url}}" target="_blank" rel="noopener">{{folderitem.title}}</a></li>
                         {% elsif page.url contains folderitem.url %}
-                        <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
+                        <li class="dropdownActive"><a href="{{folderitem.url |  relative_url}}">{{folderitem.title}}</a></li>
                         {% else %}
-                        <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                        <li><a href="{{folderitem.url | relative_url}}">{{folderitem.title}}</a></li>
                         {% endif %}
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
## Summary
- update the sidebar include to generate internal links with the Liquid `relative_url` filter
- switch the top navigation include to use `relative_url` for internal targets instead of removing leading slashes

## Testing
- `bundle exec jekyll build` *(fails: bundler cannot find `jekyll`; `bundle install` aborts because the Gemfile specifies Jekyll twice and installing Jekyll directly is blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2973256bc832cb40ca6094a31fbc6