### PR TITLE
Add quick navigation page

### DIFF
--- a/pages/quick-navigation.md
+++ b/pages/quick-navigation.md
@@ -1,0 +1,28 @@
+---
+title: "Quick Navigation"
+tags: [getting_started]
+sidebar: ccms_home_sidebar
+permalink: /quick-navigation.html
+summary: Rapid access to high-value sections of the CCMS medical documentation site
+---
+
+# Quick Navigation
+
+Use these curated links to jump directly to the most frequently referenced content areas across the CCMS documentation.
+
+## Core Medical Content
+- [Clinical Protocols](/protocols/) – Evidence-based care pathways for common conditions.
+- [Practice Guidelines](/guidelines/) – Policy-level recommendations for clinical practice.
+- [Medical Procedures](/procedures/) – Step-by-step procedural checklists for clinical teams.
+- [Medications](/medications/) – Drug references, dosing considerations, and safety alerts.
+- [References](/references/) – Source materials and further reading that support CCMS guidance.
+
+## Getting Started
+- [Homepage](/index.html) – Overview of the CCMS documentation and latest updates.
+- [Search the Knowledge Base](/search.html) – Quickly find documents across the site.
+
+## Support Resources
+- [Contact the CCMS Team](/contact.html) – Reach out for clarifications or to report issues.
+- [Change Log](/changelog.html) – Review recent updates to the documentation set.
+
+Need a link that is missing? Let the CCMS documentation team know so we can keep this hub up to date.


### PR DESCRIPTION
## Summary
- add a quick navigation landing page that matches the sidebar link and provides direct links to key CCMS resources

## Testing
- bundle exec jekyll serve --skip-initial-build *(fails: `jekyll` executable not installed because Gemfile has conflicting requirements)*
- bundle install *(fails: Gemfile has conflicting requirements for `jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_68e298e194b0832ca042666a39f016d3