### PR TITLE
Add scaffolding for new CCMS content sections

### DIFF
--- a/_data/sidebars/ccms_medications_sidebar.yml
+++ b/_data/sidebars/ccms_medications_sidebar.yml
@@ -1,14 +1,14 @@
 entries:
 - title: sidebar
-  product: Clinical Guidelines
+  product: Medication Management
   version: 1.0
   folders:
 
   - title: Overview
     output: web
     folderitems:
-    - title: Guidelines Home
-      url: /guidelines/index.html
+    - title: Medications Home
+      url: /medications/index.html
       output: web
 
   - title: Navigation

--- a/_data/sidebars/ccms_procedures_sidebar.yml
+++ b/_data/sidebars/ccms_procedures_sidebar.yml
@@ -1,14 +1,14 @@
 entries:
 - title: sidebar
-  product: Clinical Guidelines
+  product: Clinical Procedures
   version: 1.0
   folders:
 
   - title: Overview
     output: web
     folderitems:
-    - title: Guidelines Home
-      url: /guidelines/index.html
+    - title: Procedures Home
+      url: /procedures/index.html
       output: web
 
   - title: Navigation

--- a/_data/sidebars/ccms_references_sidebar.yml
+++ b/_data/sidebars/ccms_references_sidebar.yml
@@ -1,14 +1,14 @@
 entries:
 - title: sidebar
-  product: Clinical Guidelines
+  product: Clinical References
   version: 1.0
   folders:
 
   - title: Overview
     output: web
     folderitems:
-    - title: Guidelines Home
-      url: /guidelines/index.html
+    - title: References Home
+      url: /references/index.html
       output: web
 
   - title: Navigation

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -11,7 +11,11 @@ topnav_dropdowns:
       folderitems:
         - title: Protocols
           url: /protocols/
-        - title: Guidelines  
+        - title: Guidelines
           url: /guidelines/
         - title: Procedures
           url: /procedures/
+        - title: Medications
+          url: /medications/
+        - title: References
+          url: /references/

--- a/pages/guidelines/index.md
+++ b/pages/guidelines/index.md
@@ -1,0 +1,14 @@
+---
+title: "Clinical Guidelines"
+tags: [guidelines]
+sidebar: ccms_guidelines_sidebar
+permalink: /guidelines/index.html
+---
+
+# Clinical Guidelines
+
+Explore standardized guidelines that support consistent, evidence-based patient care across the CCMS network.
+
+## Coming Soon
+
+Content for priority guideline topics is under development. Check back for updates as materials are published.

--- a/pages/medications/index.md
+++ b/pages/medications/index.md
@@ -1,0 +1,14 @@
+---
+title: "Medication Management"
+tags: [medications]
+sidebar: ccms_medications_sidebar
+permalink: /medications/index.html
+---
+
+# Medication Management
+
+Resources that support safe prescribing, dispensing, and monitoring of medications will be collected here.
+
+## Coming Soon
+
+Formulary updates, dosing references, and safety alerts will be added as they become available.

--- a/pages/procedures/index.md
+++ b/pages/procedures/index.md
@@ -1,0 +1,14 @@
+---
+title: "Clinical Procedures"
+tags: [procedures]
+sidebar: ccms_procedures_sidebar
+permalink: /procedures/index.html
+---
+
+# Clinical Procedures
+
+This section will catalog standardized operating procedures and best practices for common clinical interventions.
+
+## Coming Soon
+
+Procedure checklists, competency guides, and reference materials are being prepared for publication.

--- a/pages/references/index.md
+++ b/pages/references/index.md
@@ -1,0 +1,14 @@
+---
+title: "Clinical References"
+tags: [references]
+sidebar: ccms_references_sidebar
+permalink: /references/index.html
+---
+
+# Clinical References
+
+Centralize key reference materials, quick guides, and tools that support clinical decision-making.
+
+## Coming Soon
+
+Reference tables, calculators, and external resource links will be added as they are curated.


### PR DESCRIPTION
## Summary
- add dedicated sidebars for guidelines, procedures, medications, and references
- scaffold landing pages for each new content area with matching sidebar metadata
- extend top navigation to link to the new sections

## Testing
- bundle exec jekyll build *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68e299ea4ea0832cb206c8caaffb3af4