### PR TITLE
Fix diabetes protocol link to respect baseurl

### DIFF
--- a/pages/protocols/index.md
+++ b/pages/protocols/index.md
@@ -12,7 +12,7 @@ Welcome to the CCMS Clinical Protocols section. Here you'll find evidence-based 
 ## Available Protocols
 
 ### Endocrine Disorders
-* [Diabetes Management](/protocols/diabetes-management.html) - Comprehensive diabetes care protocol.
+* [Diabetes Management]({{ site.baseurl }}/protocols/diabetes-management.html) - Comprehensive diabetes care protocol.
 
 ### Coming Soon
 * Hypertension Management


### PR DESCRIPTION
## Summary
- update the Diabetes Management protocol link to prepend `site.baseurl` so it resolves correctly on GitHub Pages deployments

## Testing
- bundle exec jekyll build *(fails: bundler cannot install because the Gemfile specifies `jekyll` twice with conflicting version constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68e29e6d4880832c9584c348e4fe0079