### PR TITLE
Remove direct Jekyll pin to rely on GitHub Pages stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 # Jekyll and GitHub Pages
-gem "jekyll", "~> 4.2"
 gem "github-pages", "~> 228", group: :jekyll_plugins
 
 # Essential plugins
@@ -24,5 +23,3 @@ end
 # Performance booster for watching directories
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
-# Lock Jekyll to prevent issues
-gem "jekyll", ">= 3.5", "< 5.0"


### PR DESCRIPTION
## Summary
- remove the standalone Jekyll gem declarations so the site uses the GitHub Pages-approved stack

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" when fetching specs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a3b30f14832c838245f8c1352975