### PR TITLE
Adjust Pages workflow cache version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ruby-version: '3.1'
           bundler-cache: true
-          cache-version: 0
+          cache-version: 1
       
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
## Summary
- bump the cache-version for the Ruby setup step to force a fresh bundle install

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a5fbbc3c832c878cbb444c717dff